### PR TITLE
feat: JWT generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,33 @@ denylists through the `publish_exclude` and `subscribe_exclude` keys, which acce
 }
 ```
 
+### Json Web Token Generator
+
+You can generate a JWT to use on the hub from the command-line:
+
+```bash
+./bin/mercure jwt:generate
+```
+
+It will ask you interactively what topic selectors you want to allow/deny for publishing/subscribing, and ask you 
+for an optional TTL.
+
+If you want a raw output (to pipe the generated JWT for instance), use the `--raw` option.
+
+To disable interaction, you can use the following example:
+
+
+```bash
+./bin/mercure jwt:generate --no-interactive --publish=/foo/{id} --publish=/bar --publish-exclude=/foo/bar
+```
+
+It will use your JWT keys environment variables, or you can use the `--jwt-key`, `--publisher-jwt-key`, `--subscriber-jwt-key` options.
+
+For a full list of available options, run this:
+
+```bash
+./bin/mercure jwt:generate -h
+```
 
 ## Tests
 

--- a/bin/mercure
+++ b/bin/mercure
@@ -3,6 +3,7 @@
 
 namespace BenTools\MercurePHP;
 
+use BenTools\MercurePHP\Command\GenerateJWTCommand;
 use BenTools\MercurePHP\Command\ServeCommand;
 use BenTools\MercurePHP\Command\StressSubscribersCommand;
 use Symfony\Component\Console\Application;
@@ -12,6 +13,7 @@ require __DIR__.'/../vendor/autoload.php';
 $application = new Application('Mercure PHP Hub');
 
 $application->add((new ServeCommand())->setName('serve'));
+$application->add((new GenerateJWTCommand())->setName('jwt:generate'));
 $application->add((new StressSubscribersCommand())->setName('stress:subscribers'));
 
 $application

--- a/src/Command/GenerateJWTCommand.php
+++ b/src/Command/GenerateJWTCommand.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace BenTools\MercurePHP\Command;
+
+use BenTools\MercurePHP\Configuration\Configuration;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Key;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function BenTools\MercurePHP\get_signer;
+
+final class GenerateJWTCommand extends Command
+{
+    private const TARGET_PUBLISHERS = 'publishers';
+    private const TARGET_SUBSCRIBERS = 'subscribers';
+    private const TARGET_BOTH = 'both';
+    private const VALID_TARGETS = [
+        self::TARGET_PUBLISHERS,
+        self::TARGET_SUBSCRIBERS,
+        self::TARGET_BOTH,
+    ];
+
+    protected static $defaultName = 'mercure:jwt:generate';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $config = Configuration::bootstrapFromCLI($input)->asArray();
+
+        $target = $input->getOption('target') ?? self::TARGET_BOTH;
+        if (!\in_array($target, self::VALID_TARGETS, true)) {
+            $io->error(\sprintf('Invalid target `%s`.', $target));
+
+            return self::FAILURE;
+        }
+
+        $values = [
+            'publish' => $input->getOption('publish'),
+            'publish_exclude' => $input->getOption('publish-exclude'),
+            'subscribe' => $input->getOption('subscribe'),
+            'subscribe_exclude' => $input->getOption('subscribe-exclude'),
+        ];
+
+        $claim = [];
+
+        if (\in_array($target, [self::TARGET_PUBLISHERS, self::TARGET_BOTH], true)) {
+            $claim = [
+                'publish' => $values['publish'],
+                'publish_exclude' => $values['publish_exclude'],
+            ];
+        }
+
+        if (\in_array($target, [self::TARGET_SUBSCRIBERS, self::TARGET_BOTH], true)) {
+            $claim = \array_merge(
+                $claim,
+                [
+                    'subscribe' => $values['subscribe'],
+                    'subscribe_exclude' => $values['subscribe_exclude'],
+                ]
+            );
+        }
+
+        $claim = \array_filter($values, fn(array $claim) => [] !== $claim);
+        $containsPublishTopics = isset($claim['publish']) || isset($claim['publish_exclude']);
+        $containsSubscribeTopics = isset($claim['subscribe']) || isset($claim['subscribe_exclude']);
+        $builder = (new Builder())->withClaim('mercure', $claim);
+
+        if (null !== $input->getOption('ttl')) {
+            $builder = $builder->expiresAt(\time() + (int) $input->getOption('ttl'));
+        }
+
+        $defaultKey = $config[Configuration::JWT_KEY];
+        $defaultAlgorithm = $config[Configuration::JWT_ALGORITHM];
+
+        if (isset($config[Configuration::PUBLISHER_JWT_KEY])) {
+            $publisherKey = $config[Configuration::PUBLISHER_JWT_KEY];
+            $publisherAlgorithm = $config[Configuration::PUBLISHER_JWT_ALGORITHM] ?? $config[Configuration::JWT_ALGORITHM];
+        }
+
+        if (isset($config[Configuration::SUBSCRIBER_JWT_KEY])) {
+            $subscriberKey = $config[Configuration::SUBSCRIBER_JWT_KEY];
+            $subscriberAlgorithm = $config[Configuration::SUBSCRIBER_JWT_ALGORITHM] ?? $config[Configuration::JWT_ALGORITHM];
+        }
+
+        if (true === $containsPublishTopics && false === $containsSubscribeTopics) {
+            $target = self::TARGET_PUBLISHERS;
+        } elseif (false === $containsPublishTopics && true === $containsSubscribeTopics) {
+            $target = self::TARGET_SUBSCRIBERS;
+        }
+
+        switch ($target) {
+            case self::TARGET_PUBLISHERS:
+                $key = $publisherKey ?? $defaultKey;
+                $algorithm = $publisherAlgorithm ?? $defaultAlgorithm;
+                break;
+            case self::TARGET_SUBSCRIBERS:
+                $key = $subscriberKey ?? $defaultKey;
+                $algorithm = $subscriberAlgorithm ?? $defaultAlgorithm;
+                break;
+            case self::TARGET_BOTH:
+            default:
+                $key = $defaultKey;
+                $algorithm = $defaultAlgorithm;
+        }
+
+        try {
+            $token = $builder->getToken(
+                get_signer($algorithm),
+                new Key($key),
+            );
+        } catch (\Exception $e) {
+            $io->error('Unable to sign your token.');
+
+            return self::FAILURE;
+        }
+
+        if (false === $input->getOption('raw')) {
+            $io->success('Here is your token! ⤵️');
+        }
+        $output->writeln((string) $token);
+
+        return self::SUCCESS;
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+        $config = Configuration::bootstrapFromCLI($input)->asArray();
+        $publishersOnly = !empty($config[Configuration::PUBLISHER_JWT_KEY]);
+        $subscribersOnly = !empty($config[Configuration::SUBSCRIBER_JWT_KEY]);
+        $forBothTargets = false === $publishersOnly && false === $subscribersOnly;
+
+        if (!$forBothTargets && empty($input->getOption('target'))) {
+            $value = $io->choice(
+                'Do you want to generate a JWT for publishers or subscribers?',
+                [
+                    self::TARGET_PUBLISHERS,
+                    self::TARGET_SUBSCRIBERS,
+                ]
+            );
+
+            $input->setOption('target', $value);
+        }
+
+        if ($forBothTargets || self::TARGET_PUBLISHERS === $input->getOption('target')) {
+            $values = (array) $input->getOption('publish');
+            if (empty($values)) {
+                ASK_PUBLISH:
+                $value = $io->ask(
+                    'Add a topic selector for the `publish` key (or just hit ENTER when you\'re done)'
+                );
+                if (null !== $value) {
+                    $values[] = $value;
+                    goto ASK_PUBLISH;
+                }
+                $input->setOption('publish', $values);
+            }
+
+            $values = (array) $input->getOption('publish-exclude');
+            if (empty($values)) {
+                ASK_PUBLISH_EXCLUDE:
+                $value = $io->ask(
+                    'Add a topic selector for the `publish-exclude` key (or just hit ENTER when you\'re done)'
+                );
+                if (null !== $value) {
+                    $values[] = $value;
+                    goto ASK_PUBLISH_EXCLUDE;
+                }
+                $input->setOption('publish-exclude', $values);
+            }
+        }
+
+        if ($forBothTargets || self::TARGET_SUBSCRIBERS === $input->getOption('target')) {
+            $values = (array) $input->getOption('subscribe');
+            if (empty($values)) {
+                ASK_SUBSCRIBE:
+                $value = $io->ask(
+                    'Add a topic selector for the `subscribe` key (or just hit ENTER when you\'re done)'
+                );
+                if (null !== $value) {
+                    $values[] = $value;
+                    goto ASK_SUBSCRIBE;
+                }
+                $input->setOption('subscribe', $values);
+            }
+
+            $values = (array) $input->getOption('subscribe-exclude');
+            if (empty($values)) {
+                ASK_SUBSCRIBE_EXCLUDE:
+                $value = $io->ask(
+                    'Add a topic selector for the `subscribe-exclude` key (or just hit ENTER when you\'re done)'
+                );
+                if (null !== $value) {
+                    $values[] = $value;
+                    goto ASK_SUBSCRIBE_EXCLUDE;
+                }
+                $input->setOption('subscribe-exclude', $values);
+            }
+        }
+
+        if (null === $input->getOption('ttl')) {
+            $value = $io->ask(
+                'TTL of this token in seconds (or hit ENTER for no expiration):',
+                null,
+                function ($value) {
+                    if (null === $value) {
+                        return null;
+                    }
+                    if (!\is_numeric($value) || $value <= 0) {
+                        throw new \RuntimeException('Invalid number.');
+                    }
+
+                    return $value;
+                }
+            );
+
+            $input->setOption('ttl', $value);
+        }
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Generates a JWT key to use on this hub.');
+        $this
+            ->addOption(
+                'publish',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Allowed topic selectors for publishing.',
+                []
+            )
+            ->addOption(
+                'publish-exclude',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Denied topic selectors for publishing.',
+                []
+            )
+            ->addOption(
+                'subscribe',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Allowed topic selectors for subscribing.',
+                []
+            )
+            ->addOption(
+                'subscribe-exclude',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Denied topic selectors for subscribing.',
+                []
+            )
+            ->addOption(
+                'target',
+                null,
+                InputOption::VALUE_OPTIONAL
+            )
+            ->addOption(
+                'ttl',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'TTL of this token, in seconds.'
+            )
+            ->addOption(
+                'raw',
+                null,
+                InputOption::VALUE_NONE,
+                'Enable raw output'
+            )
+            ->addOption(
+                'jwt-key',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The JWT key to use for both publishers and subscribers',
+            )
+            ->addOption(
+                'jwt-algorithm',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The JWT verification algorithm to use for both publishers and subscribers, e.g. HS256 (default) or RS512.',
+            )
+            ->addOption(
+                'publisher-jwt-key',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Must contain the secret key to valid publishers\' JWT, can be omitted if jwt_key is set.',
+            )
+            ->addOption(
+                'publisher-jwt-algorithm',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The JWT verification algorithm to use for publishers, e.g. HS256 (default) or RS512.',
+            )
+            ->addOption(
+                'subscriber-jwt-key',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Must contain the secret key to valid subscribers\' JWT, can be omitted if jwt_key is set.',
+            )
+            ->addOption(
+                'subscriber-jwt-algorithm',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The JWT verification algorithm to use for subscribers, e.g. HS256 (default) or RS512.',
+            );
+    }
+}

--- a/src/Command/ServeCommand.php
+++ b/src/Command/ServeCommand.php
@@ -37,11 +37,7 @@ final class ServeCommand extends Command
         $output = new SymfonyStyle($input, $output);
         $logger = $this->logger ?? new ConsoleLogger($output, [LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL]);
         try {
-            $config = (new Configuration())
-                ->overrideWith($_SERVER)
-                ->overrideWith($this->getInputOptions($input))
-                ->asArray();
-
+            $config = Configuration::bootstrapFromCLI($input)->asArray();
             $loop->futureTick(function () use ($config, $output) {
                 $this->displayConfiguration($config, $output);
             });

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -11,6 +11,8 @@ use Lcobucci\JWT\Token;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
+use function BenTools\MercurePHP\get_signer;
+
 final class Authenticator
 {
     private Parser $parser;
@@ -70,20 +72,6 @@ final class Authenticator
         }
     }
 
-    public static function getSignerFromAlgorithm(string $algorithm): Signer
-    {
-        $map = [
-            'HS256' => new Signer\Hmac\Sha256(),
-            'RS512' => new Signer\Rsa\Sha512(),
-        ];
-
-        if (!isset($map[$algorithm])) {
-            throw new \InvalidArgumentException(\sprintf('Invalid algorithm %s.', $algorithm));
-        }
-
-        return $map[$algorithm];
-    }
-
     public static function createPublisherAuthenticator(array $config): Authenticator
     {
         $publisherKey = $config[Configuration::PUBLISHER_JWT_KEY] ?? $config[Configuration::JWT_KEY];
@@ -92,7 +80,7 @@ final class Authenticator
         return new self(
             new Parser(),
             new Key($publisherKey),
-            self::getSignerFromAlgorithm($publisherAlgorithm)
+            get_signer($publisherAlgorithm)
         );
     }
 
@@ -104,7 +92,7 @@ final class Authenticator
         return new self(
             new Parser(),
             new Key($subscriberKey),
-            self::getSignerFromAlgorithm($subscriberAlgorithm)
+            get_signer($subscriberAlgorithm)
         );
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,6 +2,8 @@
 
 namespace BenTools\MercurePHP;
 
+use Lcobucci\JWT\Signer;
+
 function nullify($input)
 {
     if (!\is_scalar($input)) {
@@ -12,4 +14,18 @@ function nullify($input)
     }
 
     return $input;
+}
+
+function get_signer(string $algorithm): Signer
+{
+    $map = [
+        'HS256' => new Signer\Hmac\Sha256(),
+        'RS512' => new Signer\Rsa\Sha512(),
+    ];
+
+    if (!isset($map[$algorithm])) {
+        throw new \InvalidArgumentException(\sprintf('Invalid algorithm %s.', $algorithm));
+    }
+
+    return $map[$algorithm];
 }

--- a/tests/Unit/Command/GenerateJWTCommandTest.php
+++ b/tests/Unit/Command/GenerateJWTCommandTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace BenTools\MercurePHP\Tests\Unit\Command;
+
+use BenTools\MercurePHP\Command\GenerateJWTCommand;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Rsa\Sha512;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function BenTools\CartesianProduct\cartesian_product;
+
+$combinations = cartesian_product([
+    'publish' => [
+        null,
+        [
+            '/publish/{any}',
+            '/publish/1',
+        ],
+    ],
+    'publish_exclude' => [
+        null,
+        [
+            '/publish/2',
+        ],
+    ],
+    'subscribe' => [
+        null,
+        [
+            '/subscribe/{any}',
+            '/subscribe/1',
+        ],
+    ],
+    'subscribe_exclude' => [
+        null,
+        [
+            '/subscribe/2',
+        ],
+    ],
+    'ttl' => [
+        null,
+        300,
+    ]
+]);
+
+it('returns the desired JWT', function (
+    ?array $publish,
+    ?array $publishExclude,
+    ?array $subscribe,
+    ?array $subscribeExclude,
+    ?int $ttl
+) {
+
+    $commandArguments = [
+        '--raw' => true,
+        '--jwt-key' => 'SecretKey',
+        '--publish' => $publish ?? [],
+        '--publish-exclude' => $publishExclude ?? [],
+        '--subscribe' => $subscribe ?? [],
+        '--subscribe-exclude' => $subscribeExclude ?? [],
+        '--ttl' => $ttl,
+    ];
+
+    $command = new GenerateJWTCommand();
+        $tester = new CommandTester($command);
+        $tester->execute(
+            $commandArguments,
+            ['interactive' => false]
+        );
+        $statusCode = $tester->getStatusCode();
+        \assertEquals(Command::SUCCESS, $statusCode);
+        $output = $tester->getDisplay();
+        $token = (new Parser())->parse($output);
+
+        \assertTrue($token->hasClaim('mercure'));
+
+    $claim = (array) $token->getClaim('mercure');
+    \assertSame(null !== $publish, \array_key_exists('publish', $claim));
+    \assertSame(null !== $publishExclude, \array_key_exists('publish_exclude', $claim));
+    \assertSame(null !== $subscribe, \array_key_exists('subscribe', $claim));
+    \assertSame(null !== $subscribeExclude, \array_key_exists('subscribe_exclude', $claim));
+
+    \assertSame($publish, $claim['publish'] ?? null);
+    \assertSame($publishExclude, $claim['publish_exclude'] ?? null);
+    \assertSame($subscribe, $claim['subscribe'] ?? null);
+    \assertSame($subscribeExclude, $claim['subscribe_exclude'] ?? null);
+
+    $later = (new \DateTimeImmutable())->modify(\sprintf('+ %d seconds', (int) $ttl + 1));
+    \assertEquals(null !== $ttl, $token->isExpired($later));
+})->with($combinations);
+
+$publicKey = <<<EOF
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0j2xXywhdpkNlHfMUxuR
+2966GXjQYccP1DlxmAUyl0J+buAuNlLPVgFW/ygaF0CepKsxyv4cGYNgUnVCV+MT
+G8p+ODkwNOxGMcyjPCxYdnR9ft9XfqXcTgYuJsqJ+3+NL8OA81qy3lIhZpnw5otA
+EHTbTIBOyV2YoaM5BDZueaAxEpDLVH2lSRnqgSVsJOqAR5dAypw3YNwOio+GEDYG
+64WP8D49fdQGBg2lIO++14jyKadoWPAvzCShLTDbvXiFSPA+bEMiP/8HPRamMicG
+eRJ1nHKBNj8Ci4rAYH1vfh+Q4LTIX/yDDMctMZbhVMKYqjAbYT0x3icrqY4HuQrg
+QYONKihUXsNaT6s5OZnW9RMdBEcQ9dqCGZrWORFImytcw94f++ok6QBRsWoXPbwK
+DTCza3wOggPd3Rj6sqepkYxAQI5+FJWjazjf30dcAMUWgrcktdFc/xuAzzwdaZcI
+zZ3CmRr4KjdrBP5wD+632kp6UMGEmns8iYA1gnKUjkhRpD2yjcunffjzmeKbiqYd
+IjSPbbUFwgscKZdU3nJ+7Zue+g3GKXwvpDkNA4ZjBhd7e7L7u6cQ5rV46FnQyTMA
+tmItYsnRp3OE3nAFAKIa/09C4mlUglLjFpg3ObQbGCR9LdOXfBx2U2akjbyzC3FT
+Lxt0AMo1Po8CPSfbrmoXy1UCAwEAAQ==
+-----END PUBLIC KEY-----
+EOF;
+
+$privateKey = <<<EOF
+-----BEGIN PRIVATE KEY-----
+MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQDSPbFfLCF2mQ2U
+d8xTG5Hb3roZeNBhxw/UOXGYBTKXQn5u4C42Us9WAVb/KBoXQJ6kqzHK/hwZg2BS
+dUJX4xMbyn44OTA07EYxzKM8LFh2dH1+31d+pdxOBi4myon7f40vw4DzWrLeUiFm
+mfDmi0AQdNtMgE7JXZihozkENm55oDESkMtUfaVJGeqBJWwk6oBHl0DKnDdg3A6K
+j4YQNgbrhY/wPj191AYGDaUg777XiPIpp2hY8C/MJKEtMNu9eIVI8D5sQyI//wc9
+FqYyJwZ5EnWccoE2PwKLisBgfW9+H5DgtMhf/IMMxy0xluFUwpiqMBthPTHeJyup
+jge5CuBBg40qKFRew1pPqzk5mdb1Ex0ERxD12oIZmtY5EUibK1zD3h/76iTpAFGx
+ahc9vAoNMLNrfA6CA93dGPqyp6mRjEBAjn4UlaNrON/fR1wAxRaCtyS10Vz/G4DP
+PB1plwjNncKZGvgqN2sE/nAP7rfaSnpQwYSaezyJgDWCcpSOSFGkPbKNy6d9+POZ
+4puKph0iNI9ttQXCCxwpl1Tecn7tm576DcYpfC+kOQ0DhmMGF3t7svu7pxDmtXjo
+WdDJMwC2Yi1iydGnc4TecAUAohr/T0LiaVSCUuMWmDc5tBsYJH0t05d8HHZTZqSN
+vLMLcVMvG3QAyjU+jwI9J9uuahfLVQIDAQABAoICADnyFQQFNsfoUUzdY+x4CdCO
+574DhXOdmOhGWN+sdxAnnI9UrIf+dPTgc6jp1Z8ZCWCbaqLnPLlvc0nm1b1Bcc/U
+FMvMP1Qm1wX8v/TiyBMF8lzYk9XtQvYiT/ATHMq7kh9bBByOoAQUoO4VecchFCw0
++QhxyMVJTbsnMJzPn81X8I6MZ+5Gnxqx0Od9d/wIwgh5ULtHKSBCJqPcAPhQ28Fo
+U47EqNAYcvySIDQev/vJ2+zNHj59HL9oTSAWekoTgLDkvl+6dSMsWENnDbF+/hK6
+mr3e9WwNG9d4C6PMjsE1VAoK6btC7p/D+dnUGxDwfYFStwkrA6aWJzuZUNmYfMwx
+fzedpH7B7+8h98SRi95zQU7hiUGOZrBrKt69xDaptt4bwtUGciVvhYOHIO9YJmXf
+DhIljFOCt1Dp4gi/k7FQP4EvsEIoSpgu0/uLgiaY4I9rRTIitG5E1sO/3gtloca3
+5/LBRjmXzdqocRZo+hLZzqxq34A3o/MZcpZCgDOIb33c0srIYlA4c8ONIzqjHdNl
+Cp2LszzYHsaF4gj9YgJN3fwXwZgggrFY3j+M6sh3D/ilO5+AS6Yw0ifSvDyApuAB
++5AQ1rYGxDWvAd8nlqiuhrjOczCxD5X/7gejXFvfNHP7A3bnfkWGhdKDltSS0ApW
+ZSwI+KdGOH11XHFpWxphAoIBAQD6xT9/apIfFAgkjg3jZxCYlfSffEPTDYnkPSTt
+7u21X0OF8+QXdn2Xj7X0QlPi9zFbTrEtA2dSmuVtCucyvFUwEuuxvM+6ph618WiU
+/1Y1fny6Idb/0AGrr6z+MNwr+FVXvAb3+TS9fgHy9CI2dnAD2AinguNECV9KM2Al
+Yz4L8VFd3MYchDYLEtrFOVj14auvXp2nRE3270XCFvjHTm30zPa9zmUXLuJxsoT9
+y8P7E5xwZ3lohmAQNwJqTTbqRcDxtRH6B0tduZ+9liUvz7F+h8K+V02YVjoshy5z
+Bvx6diA8cQdp9aqyIMc7ZPbmmEk1/NOFqo+p2HrOxiBYU8JZAoIBAQDWoBNoeAQU
+L5aKL1Kj74RYEC3mtChGsKfkz487gEcX1YI8EZuC0PIcSHOMyOcOAxWUoBuxuHoh
+V1MYq3WpRiumwYdFht2kg2+cbPoyjsAzvSbFoUzib7zykrHt2gZqGR/TpKgzR9J7
+0ZExKJTe5bwjfhiEMGnGQYLiJ0U4vCl+OM5l/3s/qzdWHiRsC3JaaRdwJOnfLGDM
+icSodmtaZDDMBPbNNzg50lC3PrXDDFU0I4HuNKsQ7nbhAReDUcBVIEFZkrf0TWMx
+absdhxNvmp/QxIs1EqzsUg7W6tLtO77eOH+sY3+cXMmwD0MFF18jML3A2baDancg
+sQNU4FcKO5ldAoIBAGD1AL8H+mUvvpI7pl0FDWKhoApF5odklar8hRnFpnzYz2es
+S8VSl+6Qrv444uw/PQMbot9PkJRctVX6wDdan+lNd3mqEfsNnZQlOZVaP//A3wKs
+cM9Joku6Sb2iMI6DnqOkXGFmJiEZ5jEEeXHrSxYBYh86ORqmMQSkZokuHOBLNnV/
+Fc4SxD511MYqjR3MWjAc+gGhJC/UhXksnpWY2mSrFr9+XJGhHAZvyoHCVgzuoS7I
+oyVpxxyd2D43ioL740TRCJlOVrJvQbbwpYId4HeWkBI9+Q9sT2PGBIyO5/GFWKNl
+5ELwrEXg7IcnW1r/CFdqYHIu5wr5W0o1Sm48PEkCggEAIlPEBud7L4dU+pELFLFQ
+Z41e6hFSh8vlbpFMBWZE+KjrhZQDXW7x6lgkMxZG7lTL9NOO2mP5FLAU2FNEJGjW
+vnshmZsyhAeJqGk9syxlzWCpfN6Jn4XjoKCZ2MMQV5PhJUamqF0Ka0dfg49MEEKK
+TtryLOJZaJ49wtIpHiPqNwf66xFrswk9doanqKhEB/XbC9K7nThJ2y0FyTP3g6OW
+smrw1m3Ijmb3Bff/tkyYrBgpxeGiorihRueXzSccLgFUsnDm/yoJfXO9u8FI+Iaw
+nQFyinCMO9f8C5/PUKZHpt8+fGIFnQqyL3ihbYUJcGVxVBD+QhKbLx1gvQiMo1RY
++QKCAQEAqHS6m3zShMxbp3l1LnJCl4PNgoFplv9UqbV02Tx3MVGHh3RZo9hATery
+KjNNGv+tdPVxKIOQu2JDN+X1VvS24gcYlei2ZB0Wz8rQJfSg2FhHGT6ueiX+Bg2l
+x4ioBKNH9flFEuOad8Uoi3YOGuFpUAgE1laDI5aTuB0tBhbRj9RGo8zzaLsyslFy
+hfcjaU+apAyTyOwFQohWfQkKfMU1sM+os069KOb5uEZoxIvQwwqTYEIuEzG79JWh
+Uy/wQbkIZSUSYhpxxKTqRCT5e5KPuHxBo0kgusHfbSCYhBLp6n5My/k1Ax9KBZM8
+nC9F0lhqsnPlKZuN1dKJzcNwr8HClg==
+-----END PRIVATE KEY-----
+EOF;
+
+$combinations = cartesian_product(
+    [
+        'arguments' => [
+            [
+                '--jwt-key' => 'ASecretKey',
+                '--jwt-algorithm' => 'HS256',
+                '--publish' => ['/foo'],
+                '--subscribe' => ['/foo'],
+            ],
+            [
+                '--jwt-key' => $privateKey,
+                '--jwt-algorithm' => 'RS512',
+                '--publish' => ['/foo'],
+                '--subscribe' => ['/foo'],
+            ],
+            [
+                '--publisher-jwt-key' => 'ASecretKey',
+                '--publisher-jwt-algorithm' => 'HS256',
+                '--publish' => ['/foo'],
+            ],
+            [
+                '--publisher-jwt-key' => $privateKey,
+                '--publisher-jwt-algorithm' => 'RS512',
+                '--publish' => ['/foo'],
+            ],
+            [
+                '--jwt-key' => 'ASecretKey',
+                '--jwt-algorithm' => 'HS256',
+                '--subscriber-jwt-key' => 'ASecretKey',
+                '--subscriber-jwt-algorithm' => 'HS256',
+                '--subscribe' => ['/foo'],
+            ],
+            [
+                '--jwt-key' => 'ASecretKey',
+                '--jwt-algorithm' => 'HS256',
+                '--subscriber-jwt-key' => $privateKey,
+                '--subscriber-jwt-algorithm' => 'RS512',
+                '--subscribe' => ['/foo'],
+            ],
+        ],
+    ],
+);
+
+it(
+    'signs the JWT with the appropriate key & algorithm',
+    function (array $commandArguments) use ($publicKey) {
+        $command = new GenerateJWTCommand();
+        $tester = new CommandTester($command);
+        $tester->execute(
+            \array_merge(['--raw' => true], $commandArguments),
+            ['interactive' => false]
+        );
+        $statusCode = $tester->getStatusCode();
+        \assertEquals(Command::SUCCESS, $statusCode);
+
+        $output = $tester->getDisplay();
+
+        $token = (new Parser())->parse($output);
+        $algorithms = [
+            $commandArguments['--jwt-algorithm'] ?? null,
+            $commandArguments['--publisher-jwt-algorithm'] ?? null,
+            $commandArguments['--subscriber-jwt-algorithm'] ?? null,
+        ];
+        if (\in_array('RS512', $algorithms, true)) {
+            \assertTrue($token->verify(new Sha512(), new Key($publicKey)));
+        } else {
+            \assertTrue($token->verify(new Sha256(), new Key('ASecretKey')));
+        }
+    }
+)->with($combinations);


### PR DESCRIPTION
This PR adds a CLI utility to generate a JWT based on the hub's JWT authentication configuration.

### Usage

```bash
./bin/mercure jwt:generate
```

It will ask you interactively what topic selectors you want to allow/deny for publishing/subscribing, and ask you 
for an optional TTL.

If you want a raw output (to pipe the generated JWT for instance), use the `--raw` option.

To disable interaction, you can use the following example:


```bash
./bin/mercure jwt:generate --no-interactive --publish=/foo/{id} --publish=/bar --publish-exclude=/foo/bar
```

It will use your JWT keys environment variables, or you can use the `--jwt-key`, `--publisher-jwt-key`, `--subscriber-jwt-key` options.

For a full list of available options, run this:

```bash
./bin/mercure jwt:generate -h
```