### PR TITLE
Refactor: remove ReactPHP EventLoop from Hub/HubFactory contracts

### DIFF
--- a/src/Command/ServeCommand.php
+++ b/src/Command/ServeCommand.php
@@ -43,7 +43,7 @@ final class ServeCommand extends Command
             });
 
             $hub = (new HubFactory($config, $logger))->create($loop);
-            $hub->run($loop);
+            $hub->run();
 
             if (\SIGINT === $hub->getShutdownSignal()) {
                 $output->newLine(2);

--- a/src/Command/ServeCommand.php
+++ b/src/Command/ServeCommand.php
@@ -42,7 +42,7 @@ final class ServeCommand extends Command
                 $this->displayConfiguration($config, $output);
             });
 
-            $hub = (new HubFactory($config, $logger))->create($loop);
+            $hub = (new HubFactory($config, $loop, $logger))->create();
             $hub->run();
 
             if (\SIGINT === $hub->getShutdownSignal()) {

--- a/src/Hub/HubFactory.php
+++ b/src/Hub/HubFactory.php
@@ -35,36 +35,39 @@ final class HubFactory
     use LoggerAwareTrait;
 
     private array $config;
+    private LoopInterface $loop;
     private ?TransportFactoryInterface $transportFactory;
     private ?StorageFactoryInterface $storageFactory;
     private ?MetricsHandlerFactoryInterface $metricsHandlerFactory;
 
     public function __construct(
         array $config,
+        LoopInterface $loop,
         ?LoggerInterface $logger = null,
         ?TransportFactoryInterface $transportFactory = null,
         ?StorageFactoryInterface $storageFactory = null,
         ?MetricsHandlerFactoryInterface $metricsHandlerFactory = null
     ) {
         $this->config = $config;
+        $this->loop = $loop;
         $this->logger = $logger ?? new NullLogger();
         $this->transportFactory = $transportFactory;
         $this->storageFactory = $storageFactory;
         $this->metricsHandlerFactory = $metricsHandlerFactory;
     }
 
-    public function create(LoopInterface $loop): Hub
+    public function create(): Hub
     {
-        $transport = $this->createTransport($loop);
-        $storage = $this->createStorage($loop);
-        $metricsHandler = $this->createMetricsHandler($loop);
+        $transport = $this->createTransport($this->loop);
+        $storage = $this->createStorage($this->loop);
+        $metricsHandler = $this->createMetricsHandler($this->loop);
 
         $subscriberAuthenticator = Authenticator::createSubscriberAuthenticator($this->config);
         $publisherAuthenticator = Authenticator::createPublisherAuthenticator($this->config);
 
         $controllers = [
             new HealthController(),
-            (new SubscribeController($this->config, $subscriberAuthenticator, $loop))
+            (new SubscribeController($this->config, $subscriberAuthenticator, $this->loop))
                 ->withTransport($transport)
                 ->withStorage($storage)
                 ->withLogger($this->logger())
@@ -78,7 +81,7 @@ final class HubFactory
 
         $requestHandler = new RequestHandler($controllers);
 
-        return new Hub($this->config, $loop, $requestHandler, $metricsHandler, $this->logger());
+        return new Hub($this->config, $this->loop, $requestHandler, $metricsHandler, $this->logger());
     }
 
     private function createTransport(LoopInterface $loop): TransportInterface

--- a/src/Hub/HubFactory.php
+++ b/src/Hub/HubFactory.php
@@ -78,7 +78,7 @@ final class HubFactory
 
         $requestHandler = new RequestHandler($controllers);
 
-        return new Hub($this->config, $requestHandler, $metricsHandler, $this->logger());
+        return new Hub($this->config, $loop, $requestHandler, $metricsHandler, $this->logger());
     }
 
     private function createTransport(LoopInterface $loop): TransportInterface

--- a/tests/Unit/Hub/HubFactoryTest.php
+++ b/tests/Unit/Hub/HubFactoryTest.php
@@ -15,8 +15,9 @@ it('yells if it does not recognize the transport scheme', function () {
         Configuration::JWT_KEY => 'foo',
         Configuration::TRANSPORT_URL => 'null://localhost',
     ]);
-    $factory = new HubFactory($config->asArray(), new NullLogger(), new TransportFactory([]));
-    $factory->create(Factory::create());
+    $loop = Factory::create();
+    $factory = new HubFactory($config->asArray(), $loop, new NullLogger(), new TransportFactory([]));
+    $factory->create();
 })
 ->throws(
     \RuntimeException::class,
@@ -29,10 +30,12 @@ it('creates a hub otherwise', function () {
         Configuration::TRANSPORT_URL => 'null://localhost',
         Configuration::METRICS_URL => 'php://localhost',
     ]);
+    $loop = Factory::create();
     $hub = (new HubFactory(
         $config->asArray(),
+        $loop,
         new NullLogger(),
         new NullTransportFactory()
-    ))->create(Factory::create());
+    ))->create();
     \assertInstanceOf(Hub::class, $hub);
 });

--- a/tests/Unit/Hub/HubTest.php
+++ b/tests/Unit/Hub/HubTest.php
@@ -36,12 +36,14 @@ $transportFactory = new class implements TransportFactoryInterface {
         return resolve(new NullTransport());
     }
 };
+$loop = Factory::create();
 $hub = (new HubFactory(
     $config->asArray(),
+    $loop,
     new NullLogger(),
     new NullTransportFactory(),
     new NullStorageFactory()
-))->create(Factory::create());
+))->create();
 
 
 it('returns 200 when asking for health', function () use ($hub) {


### PR DESCRIPTION
ReactPHP's EventLoop is part of Hub / HubFactory's dependencies, not contracts (e.g. contractually a Hub doesn't need a Loop to run).