### PR TITLE
fix: CORS

### DIFF
--- a/src/Controller/SubscribeController.php
+++ b/src/Controller/SubscribeController.php
@@ -42,11 +42,12 @@ final class SubscribeController extends AbstractController
 
     public function __invoke(Request $request): ResponseInterface
     {
-        $request = $this->withAttributes($request);
 
         if ('OPTIONS' === $request->getMethod()) {
             return new Response(200);
         }
+
+        $request = $this->withAttributes($request);
 
         $stream = new ThroughStream();
 

--- a/src/Security/CORS.php
+++ b/src/Security/CORS.php
@@ -6,6 +6,8 @@ use BenTools\MercurePHP\Configuration\Configuration;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function BenTools\MercurePHP\nullify;
+
 final class CORS
 {
     private array $subscriberConfig;
@@ -31,7 +33,7 @@ final class CORS
 
     private function getCorsHeaders(ServerRequestInterface $request): array
     {
-        $origin = $request->getHeaderLine('Origin');
+        $origin = nullify($request->getHeaderLine('Origin')) ?? nullify($request->getHeaderLine('Referer'));
         if (!$origin) {
             return [];
         }

--- a/tests/Unit/Security/CORSTest.php
+++ b/tests/Unit/Security/CORSTest.php
@@ -10,11 +10,11 @@ use RingCentral\Psr7\ServerRequest;
 
 use function BenTools\CartesianProduct\cartesian_product;
 
-function createRequest(string $method, string $origin = null): ServerRequestInterface
+function createRequest(string $method, string $headerName, string $origin = null): ServerRequestInterface
 {
     $request = new ServerRequest($method, '/');
     if (null !== $origin) {
-        $request = $request->withHeader('Origin', $origin);
+        $request = $request->withHeader($headerName, $origin);
     }
 
     return $request;
@@ -37,6 +37,10 @@ $combinations = cartesian_product(
             'http://good.example.com',
             'http://bad.example.com',
             null,
+        ],
+        'header_name' => [
+            'Origin',
+            'Referer',
         ],
         'cors_allowed_origins' => [
             '*',
@@ -81,6 +85,7 @@ it(
     function (
         string $method,
         ?string $origin,
+        string $headerName,
         string $allowedOrigins,
         ?string $publishAllowedOrigins,
         ?string $expected
@@ -92,9 +97,10 @@ it(
                 Configuration::PUBLISH_ALLOWED_ORIGINS => $publishAllowedOrigins,
             ]
         );
-        $request = createRequest($method, $origin);
+        $request = createRequest($method, $headerName, $origin);
         $cors = new CORS($config->asArray());
         $response = $cors->decorateResponse($request, createResponse());
         \assertEquals($expected, $response->getHeaderLine('Access-Control-Allow-Origin'));
+        \assertEquals(200, $response->getStatusCode());
     }
 )->with($combinations);


### PR DESCRIPTION
This PR fixes CORS preflight failing when the browser:
- Sends a `Referer` header instead of `Origin`
- Gets a 400 status code when making an `OPTIONS` request.